### PR TITLE
tox: remove unnecessary workspace related changes

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,8 @@
 envlist = py35, packaging
 
 [testenv]
-setenv = WORKSPACE=.tox/tmp
 deps = 
 commands =
-	python -c 'import os; os.makedirs(os.environ["WORKSPACE"], exist_ok=True)'
 	python setup.py test -- {posargs}
 usedevelop = True
 


### PR DESCRIPTION
Those were needed for a specific use case of pytest-shutil.