### PR TITLE
Fix setuptools requirement and tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ keywords = plover plover_plugin
 [options]
 zip_safe = True
 setup_requires =
-	setuptools>=30.3.0
+	setuptools>=36.7.0
 	setuptools-scm
 install_requires =
 	plover>=4.0.0.dev1

--- a/test/test_eclipse_dict.py
+++ b/test/test_eclipse_dict.py
@@ -60,5 +60,5 @@ class TestCase(unittest.TestCase):
             INV_EXPECTED[v].append(k)
 
         for v, keylist in sorted(INV_EXPECTED.items()):
-            self.assertEqual(d.reverse_lookup(v), keylist)
+            self.assertEqual(sorted(d.reverse_lookup(v)), sorted(keylist))
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 envlist = py35, packaging
 
 [testenv]
-deps = 
+deps = setuptools>=36.7.0
 commands =
 	python setup.py test -- {posargs}
 usedevelop = True


### PR DESCRIPTION
* setup: update setuptools requirement: at least 36.7.0 is needed for proper support of `setup_requires` in `setup.cfg`.
* tox: fix dependencies: ensure a recent enough version of setuptools is installed so `setup.cfg` is correctly handled
* tests: fix tests when running on Python 3.6